### PR TITLE
Adding docker-cleanup package for distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 env:
   - PACKAGE=generate-certificate
   - PACKAGE=traefik
+  - PACKAGE=docker-cleanup
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ for building generic Mantl utilities.
         - [Core](#core)
             - [generate-certificate](#generate-certificate)
             - [traefik](#traefik)
+            - [docker-cleanup](#docker-cleanup)
     - [Building](#building)
 
 <!-- markdown-toc end -->
@@ -64,8 +65,21 @@ A script to generate certificates with a number of sensible defaults set.
 
 #### docker-cleanup
 
-A cron.hourly script to garbage collect Docker containers. Uses
-`spotify/docker-gc` and `martin/docker-cleanup-volumes` together.
+[ ![Download](https://api.bintray.com/packages/asteris/mantl-rpm/docker-cleanup/images/download.svg) ](https://bintray/asteris/mantl-rpm/docker-cleanup/_latestVersion)
+
+[*spec*](packages/docker-cleanup/spec.yml)
+
+A cron.hourly script and a few configuration files to take out the garbage.
+Uses `spotify/docker-gc` and `martin/docker-cleanup-volumes` Docker containers in tandem.
+
+First, `spotify/docker-gc` runs, and removes any containers that have been in an exit status for more than an hour.
+Spotify's container also supports excluding containers at this step. Two files control this:
+`/etc/docker-cleanup/docker-gc-exclude` to match image names and docker hashes, and
+`/etc/docker-cleanup/docker-gc-exclude-containers` to match container names. Both of these files have example lines
+for your reference.
+
+Second, `martin/docker-cleanup-volumes` removes orphaned Docker volumes, something that removing containers with docker
+commands normally does not do. Docker version 1.9 is beginning to address this issue, but this adds support for previous versions.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ A script to generate certificates with a number of sensible defaults set.
 
 - [Traefik's README](https://github.com/EmileVauge/traefik)
 
-#### docker-gc
+#### docker-cleanup
 
 A cron.hourly script to garbage collect Docker containers. Uses
-`spotify/docker-gc`. This is currently being tested!
+`spotify/docker-gc` and `martin/docker-cleanup-volumes` together.
 
 ## Building
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  config.vm.box = "chef/centos-7.0"
+  config.vm.box = "asteris/centos-7-hammer"
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--cpus", "4"]

--- a/packages/docker-cleanup/docker-cleanup
+++ b/packages/docker-cleanup/docker-cleanup
@@ -1,2 +1,0 @@
-docker run -v /var/run/docker.sock:/var/run/docker.sock -v /etc:/etc/ --rm spotify/docker-gc
-docker run -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes

--- a/packages/docker-cleanup/docker-cleanup-cron
+++ b/packages/docker-cleanup/docker-cleanup-cron
@@ -1,0 +1,2 @@
+docker run -v /var/run/docker.sock:/var/run/docker.sock -v /etc/docker-cleanup:/etc/ --rm spotify/docker-gc
+docker run -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes

--- a/packages/docker-cleanup/docker-cleanup-etc/docker-gc-exclude
+++ b/packages/docker-cleanup/docker-cleanup-etc/docker-gc-exclude
@@ -1,0 +1,1 @@
+# this file is used for exluding docker images from cleanup

--- a/packages/docker-cleanup/docker-cleanup-etc/docker-gc-exclude
+++ b/packages/docker-cleanup/docker-cleanup-etc/docker-gc-exclude
@@ -1,1 +1,6 @@
 # this file is used for exluding docker images from cleanup
+# the lines come in two forms:
+# image:tag
+#   hello-world:latest
+# docker hash
+#   1337deadbeef

--- a/packages/docker-cleanup/docker-cleanup-etc/docker-gc-exclude-containers
+++ b/packages/docker-cleanup/docker-cleanup-etc/docker-gc-exclude-containers
@@ -1,0 +1,1 @@
+# this file is for excluding specific containers

--- a/packages/docker-cleanup/docker-cleanup-etc/docker-gc-exclude-containers
+++ b/packages/docker-cleanup/docker-cleanup-etc/docker-gc-exclude-containers
@@ -1,1 +1,4 @@
 # this file is for excluding specific containers
+# the lines are based on container names
+# mariadb-data
+# drunk_goodall

--- a/packages/docker-cleanup/spec.yml
+++ b/packages/docker-cleanup/spec.yml
@@ -1,6 +1,6 @@
 ---
 name: docker-cleanup
-version: 0.0.3-alpha
+version: 0.0.4-alpha
 license: Apache 2.0
 iteration: 1
 vendor: Asteris
@@ -8,8 +8,14 @@ architecture: noarch
 type: rpm
 
 targets:
-  - src: '{{.SpecRoot}}/docker-cleanup'
-    dest: /etc/cron.hourly/
+  - src: '{{.SpecRoot}}/docker-cleanup-cron'
+    dest: /etc/cron.hourly/docker-cleanup
+  - src: '{{.SpecRoot}}/docker-cleanup-etc/docker-gc-exclude'
+    dest: /etc/docker-cleanup/docker-gc-exclude
+    config: true
+  - src: '{{.SpecRoot}}/docker-cleanup-etc/docker-gc-exclude-containers'
+    dest: /etc/docker-cleanup/docker-gc-exclude-containers
+    config: true
 
 scripts:
   after-install: |

--- a/packages/docker-cleanup/spec.yml
+++ b/packages/docker-cleanup/spec.yml
@@ -1,7 +1,7 @@
 ---
 name: docker-cleanup
 version: 0.0.4-alpha
-license: Apache 2.0
+license: ASL 2.0
 iteration: 1
 vendor: Asteris
 architecture: noarch

--- a/packages/docker-cleanup/spec.yml
+++ b/packages/docker-cleanup/spec.yml
@@ -1,6 +1,6 @@
 ---
 name: docker-cleanup
-version: 0.0.4-alpha
+version: 0.0.1
 license: ASL 2.0
 iteration: 1
 vendor: Asteris


### PR DESCRIPTION
This package adds a cron.hourly job to remove old containers and orphaned volumes by bundling two existing docker images, and some configuration files. This addresses ciscocloud/microservices-infrastructure#772