### PR TITLE
update traefik version

### DIFF
--- a/packages/traefik/spec.yml
+++ b/packages/traefik/spec.yml
@@ -1,7 +1,7 @@
 ---
 name: traefik
 version: 0.0.0
-epoch: 285
+epoch: 341
 iteration: 6
 license: MIT
 vendor: Emile Vauge

--- a/packages/traefik/spec.yml
+++ b/packages/traefik/spec.yml
@@ -16,9 +16,9 @@ dependencies:
   - sudo
 
 resources:
-  - url: https://github.com/emilevauge/traefik/releases/download/v1.0.alpha.285/traefik_linux-amd64
+  - url: https://github.com/emilevauge/traefik/releases/download/v1.0.alpha.341/traefik_linux-amd64
     hash-type: sha1
-    hash: 01564a14919fd364000e085e4aa2a29d134d3d90
+    hash: 554e4124354d95c14b4109027abcd1f6e0b2e37f
 
 targets:
   # base


### PR DESCRIPTION
Update traefik binary to include latest fix https://github.com/emilevauge/traefik/pull/137 that helps with mantl cassandra deployment.