### PR TITLE
Traefik logrotate exclude

### DIFF
--- a/packages/traefik/spec.yml
+++ b/packages/traefik/spec.yml
@@ -2,7 +2,7 @@
 name: traefik
 version: 0.0.0
 epoch: 341
-iteration: 7
+iteration: 8
 license: MIT
 vendor: Emile Vauge
 architecture: x86_64

--- a/packages/traefik/spec.yml
+++ b/packages/traefik/spec.yml
@@ -92,3 +92,4 @@ extra-args: |
   --rpm-auto-add-exclude-directories /etc/systemd
   --rpm-auto-add-exclude-directories /etc/systemd/system
   --rpm-auto-add-exclude-directories /etc/sudoers.d
+  --rpm-auto-add-exclude-directories /etc/logrotate.d


### PR DESCRIPTION
yum install of the package is failing due to conflict on /etc/logrotate.d/ folder