### PR TITLE
Add chown consul:consul /etc/consul /var/lib/consul to before_upgrade

### DIFF
--- a/consul/consul/spec.yml
+++ b/consul/consul/spec.yml
@@ -83,6 +83,9 @@ scripts:
     usermod -s /bin/bash consul
 
   after-upgrade: |
+    chown consul:consul /var/lib/consul
+    chown consul:consul /etc/consul
+
     systemctl reload-daemon
     systemctl restart consul.service
 


### PR DESCRIPTION
Older vagrant boxes have /etc/consul and /var/lib/consul owned by
root:root and aren't modified.