### PR TITLE
Adds Restart directive to traefik.service

### DIFF
--- a/packages/traefik/traefik.service
+++ b/packages/traefik/traefik.service
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/{{.Name}} /etc/{{.Name}}/{{.Name}}.toml
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitNOFILE=65536
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I left #7 hanging for a bit, but here is the fix. What is the best way to test this on a cluster?