### PR TITLE
mantl-dns: add search paths

### DIFF
--- a/mantl/mantl-dns/resolv.conf
+++ b/mantl/mantl-dns/resolv.conf
@@ -1,0 +1,6 @@
+# this configuration also adds search paths to resolv.conf so that the system
+# can address nodes by their simplest name (x.node.consul becomes x.node or
+# simply x.) This will work for service addressing as well, so you can use
+# y.service instead of y.service.consul
+search node.consul consul
+nameserver 127.0.0.1

--- a/mantl/mantl-dns/spec.yml
+++ b/mantl/mantl-dns/spec.yml
@@ -1,8 +1,8 @@
 ---
 name: mantl-dns
-version: 1.0.0
+version: 1.1.0
 license: ASL 2.0
-iteration: 2
+iteration: 1
 vendor: Asteris
 url: https://github.com/asteris-llc/mantl-packaging
 description: DNS integration with Consul
@@ -34,8 +34,14 @@ scripts:
 
     # move the existing resolv.conf and direct *all* queries to localhost.
     # dnsmasq will read the resolv.conf.masq and forward traffic accordingly
+    #
+    # this configuration also adds search paths to resolv.conf so that the
+    # system can address nodes by their simplest name (x.node.consul becomes
+    # x.node or simply x.) This will work for service addressing as well, so
+    # you can use y.service instead of y.service.consul
     mv /etc/resolv.conf /etc/resolv.conf.masq
-    echo nameserver 127.0.0.1 > /etc/resolv.conf
+    echo search node.consul consul > /etc/resolv.conf
+    echo nameserver 127.0.0.1 >> /etc/resolv.conf
 
     # restart everything to pick up the new changes
     systemctl enable dnsmasq 2>/dev/null

--- a/mantl/mantl-dns/spec.yml
+++ b/mantl/mantl-dns/spec.yml
@@ -18,10 +18,15 @@ targets:
   - src: "{{.SpecRoot}}/10-consul"
     dest: /etc/dnsmasq.d/
     config: true
+  - src: "{{.SpecRoot}}/resolv.conf"
+    dest: /etc/resolv.conf.mantl-dns
+    config: true
 
 scripts:
   before-install: |
     mkdir -p /etc/dnsmasq.d
+    mv /etc/resolv.conf /etc/resolv.conf.masq
+    ln -s /etc/resolv.conf.mantl-dns /etc/resolv.conf
 
   after-install: |
     # turn off PEERDNS on all interfaces
@@ -32,17 +37,6 @@ scripts:
     # overwrite /etc/resolv.conf every time it starts up
     sed -i '/^\[main\]$/a dns=none' /etc/NetworkManager/NetworkManager.conf
 
-    # move the existing resolv.conf and direct *all* queries to localhost.
-    # dnsmasq will read the resolv.conf.masq and forward traffic accordingly
-    #
-    # this configuration also adds search paths to resolv.conf so that the
-    # system can address nodes by their simplest name (x.node.consul becomes
-    # x.node or simply x.) This will work for service addressing as well, so
-    # you can use y.service instead of y.service.consul
-    mv /etc/resolv.conf /etc/resolv.conf.masq
-    echo search node.consul consul > /etc/resolv.conf
-    echo nameserver 127.0.0.1 >> /etc/resolv.conf
-
     # restart everything to pick up the new changes
     systemctl enable dnsmasq 2>/dev/null
     systemctl restart NetworkManager dnsmasq
@@ -52,11 +46,12 @@ scripts:
 
   before-remove: |
     sed -i '/dns=none/d' /etc/NetworkManager/NetworkManager.conf
-    mv /etc/resolv.conf.masq /etc/resolv.conf
+    rm /etc/resolv.conf
 
   after-remove: |
     # not disabling dnsmasq here because the user might be using it still.
     systemctl restart NetworkManager dnsmasq
+    mv /etc/resolv.conf.masq /etc/resolv.conf
 
 extra-args: |
   --rpm-os linux

--- a/mantl/mantl-dns/spec.yml
+++ b/mantl/mantl-dns/spec.yml
@@ -28,6 +28,14 @@ scripts:
     mv /etc/resolv.conf /etc/resolv.conf.masq
     ln -s /etc/resolv.conf.mantl-dns /etc/resolv.conf
 
+  before-upgrade: |
+    if [ ! -f /etc/resolv.conf.masq ]; then
+        mv /etc/resolv.conf /etc/resolv.conf.masq
+    else
+        rm /etc/resolv.conf
+        ln -s /etc/resolv.conf.mantl-dns /etc/resolv.conf
+    fi
+
   after-install: |
     # turn off PEERDNS on all interfaces
     find /etc/sysconfig/network-scripts -name 'ifcfg-*' \


### PR DESCRIPTION
Relevant documentation in the script:

```
# this configuration also adds search paths to resolv.conf so that the
# system can address nodes by their simplest name (x.node.consul becomes
# x.node or simply x.) This will work for service addressing as well, so
# you can use y.service instead of y.service.consul
```

Fixes #43. Feedback welcome, @josdotso and @stevendborrelli 