### PR TITLE
Update traefik to v1.0.0-beta.408

### DIFF
--- a/packages/traefik/spec.yml
+++ b/packages/traefik/spec.yml
@@ -1,7 +1,7 @@
 ---
 name: traefik
 version: 0.0.0
-iteration: 11
+iteration: 12
 license: MIT
 vendor: Emile Vauge
 architecture: x86_64
@@ -12,7 +12,7 @@ description: Træfɪk, a modern reverse proxy
 # this field means nothing now that they've switched from numbers to git hashes.
 # However, we need to keep it around until the version actually changes. Bump
 # this and iteration until then.
-epoch: 413
+epoch: 414
 
 dependencies:
   - libcap
@@ -20,7 +20,7 @@ dependencies:
   - sudo
 
 resources:
-  - url: https://github.com/containous/traefik/releases/download/v1.0.alpha.9830086790caf40ce30eb9ed5d317917f8157708/traefik_linux-amd64
+  - url: https://github.com/containous/traefik/releases/download/v1.0.0-beta.408/traefik_linux-amd64
     hash-type: sha1
     hash: 612575e288157f814cecbceb7a91a6c5072b0586
 

--- a/packages/traefik/spec.yml
+++ b/packages/traefik/spec.yml
@@ -22,7 +22,7 @@ dependencies:
 resources:
   - url: https://github.com/containous/traefik/releases/download/v1.0.0-beta.408/traefik_linux-amd64
     hash-type: sha1
-    hash: 612575e288157f814cecbceb7a91a6c5072b0586
+    hash: 25cbad4d5657a104ed8ad731620ff9e7866e4d7b
 
 targets:
   # base


### PR DESCRIPTION
Updated traefik to v1.0.0-beta.408.  

FYI - I was not sure what that ```epoch``` value was used for so I just incremented it.  Is it supposed to match the Traefik version (408)? 

Traefik seems to have switched back from git hashes to numbers again once they went to beta versions.