### PR TITLE
Add CAdvisor health check

### DIFF
--- a/distributive/distributive-cadvisor/distributive-cadvisor.yml
+++ b/distributive/distributive-cadvisor/distributive-cadvisor.yml
@@ -1,0 +1,6 @@
+---
+name: CAdvisor health check
+checklist:
+  - name: mantl-cadvisor docker container running
+    id: dockerRunningRegexp
+    parameters: ['mantl-cadvisor']

--- a/distributive/distributive-cadvisor/spec.yml
+++ b/distributive/distributive-cadvisor/spec.yml
@@ -1,0 +1,14 @@
+
+name: distributive-cadvisor
+version: 0.1
+iteration: 1
+license: ASL 2.0
+description: >
+  distributive-cadvisor is a distributive checklist that checks the health of
+  CAdvisor as it runs on Mantl.
+url: https://github.com/asteris-llc/mantl-packaging
+type: rpm
+
+targets:
+  - src: "{{.SpecRoot}}/distributive-cadvisor.yml"
+    dest: /etc/distributive.d/distributive-cadvisor.json


### PR DESCRIPTION
Tested locally with distributive binary compiled from master, note that this won't work until the next version of distributive is released. 