### PR TITLE
Use env vars from dedicated bintray file

### DIFF
--- a/.bintray
+++ b/.bintray
@@ -1,1 +1,1 @@
-BINTRAY_PROJECT=asteris/mantl-1.1.0
+BINTRAY_PROJECT=shippedrepos/mantl-1.2

--- a/.bintray
+++ b/.bintray
@@ -1,0 +1,1 @@
+BINTRAY_PROJECT=asteris/mantl-1.1.0

--- a/scripts/bintray.sh
+++ b/scripts/bintray.sh
@@ -1,7 +1,12 @@
-#/bin/bash
+#!/bin/bash
+# This script has to be executed from the root mantl-packaging directory.
 set -e
 
 OUTPUT=${1:-out}
+
+if [ -f ./.bintray ]; then
+    source .bintray
+fi
 
 if curl -s -I "https://api.bintray.com/repos/$BINTRAY_PROJECT" | grep -q 404; then
     echo "package repository not found, creating repository"


### PR DESCRIPTION
BINTRAY_PROJECT env var is sourced from .bintray file,
the default value for that env var is defined in travis-ci.