### PR TITLE
MANTL-LOGS Add initial PoC+notes for package

### DIFF
--- a/mantl/mantl-logs/mantl-logs.go
+++ b/mantl/mantl-logs/mantl-logs.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"log"
+	"os"
+)
+
+func bundleLogFile(tarball *tar.Writer, filepath string) error {
+
+	log.Printf("archiving %s\n", filepath)
+
+	logfile, err := os.Open(filepath)
+	if err != nil {
+		return err
+	}
+	defer logfile.Close()
+
+	info, err := logfile.Stat()
+	if err != nil {
+		return err
+	}
+	hdr, err := tar.FileInfoHeader(info, info.Name())
+	if err != nil {
+		return err
+	}
+
+	if err := tarball.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(logfile)
+	scanner.Split(bufio.ScanBytes)
+	for scanner.Scan() {
+		if _, err := tarball.Write(scanner.Bytes()); err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
+func main() {
+
+	bundle, err := os.Create("bundle.tar")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer bundle.Close()
+
+	tarball := tar.NewWriter(bundle)
+
+	logfiles, err := os.Open(".logfiles")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer logfiles.Close()
+
+	scanner := bufio.NewScanner(logfiles)
+	for scanner.Scan() {
+		if err := bundleLogFile(tarball, scanner.Text()); err != nil {
+			log.Fatalln(err)
+		}
+	}
+
+	if err := tarball.Close(); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/mantl/mantl-logs/notes
+++ b/mantl/mantl-logs/notes
@@ -1,0 +1,22 @@
+The idea here is that we provide a utility for users/customers to upload bundles of logs for tech support.
+./mantl-logs --upload --customer-id --name
+interact with consul-cli
+
+
+What it needs to do...
+	gather log files/directories into an archive
+		default paths are in a file that can be edited by user
+	add a bug report, with comments from user
+	send it someplace
+	take config options for where to send it
+	take config for user metadata
+	extensions
+		take config for what to bundle
+		different archive formats
+		post to GH/gist/etc.
+
+TODOS:
+	explore what ansible logs look like, see about including them in an upload.
+	talk to mgmt about what customer support looks like
+		propose that we have a support.json file that gets downloaded to their mantl install
+			that file will configure how uploads occur

--- a/mantl/mantl-logs/spec.yml
+++ b/mantl/mantl-logs/spec.yml
@@ -1,0 +1,12 @@
+---
+name: mantl-logs
+version: 0.0.1
+license: ASL 2.0
+iteration: 1
+vendor: Asteris
+url: https://github.com/asteris-llc/mantl-packaging
+description: Log bundler utility for mantl
+type: rpm
+
+depends:
+  - consul-cli


### PR DESCRIPTION
Recently, I've been working on caching logs for failed Travis builds.
Steve then started riffing off of this and started describing a support
tool for bundling logs and uploading them, to make bug reports easier
for everyone. This is the PoC of that, and eyeballs and criticisms are
welcome.