### PR TITLE
traefik: upgrade to 1.0-rc1

### DIFF
--- a/packages/traefik/spec.yml
+++ b/packages/traefik/spec.yml
@@ -1,19 +1,19 @@
 ---
 name: traefik
 version: 1.0.0
-iteration: beta.475
-epoch: 1
+iteration: rc1
 license: MIT
+epoch: 414
 vendor: Emile Vauge
 architecture: x86_64
 type: rpm
-url: https://github.com/EmileVauge/traefik
+url: https://github.com/containous/traefik
 description: Træfɪk, a modern reverse proxy
 
 # this field means nothing now that they've switched from numbers to git hashes.
 # However, we need to keep it around until the version actually changes. Bump
 # this and iteration until then.
-epoch: 413
+epoch: 414
 
 dependencies:
   - libcap
@@ -21,27 +21,27 @@ dependencies:
   - sudo
 
 resources:
-  - url: https://github.com/containous/traefik/releases/download/v1.0.0-beta.475/traefik_linux-amd64
-    hash-type: sha1
-    hash: 4a6f007178e70ef78b6fb266d8bb501fc776c0fc
+  - url: '{{.URL}}/releases/download/v{{.Version}}-{{.Iteration}}/{{.Name}}_linux-amd64'
+    hash-type: sha256
+    hash: d3862ad9e46f3fe18a04882c71c09c748781829d8542d9c9e6954b8de167e14b
 
 targets:
   # base
-  - src: '{{.BuildRoot}}/traefik_linux-amd64'
+  - src: '{{.BuildRoot}}/{{.Name}}_linux-amd64'
     dest: /usr/bin/{{.Name}}
   - src: '{{.SpecRoot}}/{{.Name}}.service'
     dest: /etc/systemd/system/{{.Name}}.service
     template: yes
   - src: '{{empty}}'
-    dest: /etc/traefik
+    dest: /etc/{{.Name}}
   - src: '{{empty}}'
-    dest: /etc/traefik/configs
+    dest: /etc/{{.Name}}/configs
 
   # logging
-  - src: '{{.SpecRoot}}/logrotate/traefik'
-    dest: /etc/logrotate.d/traefik
-  - src: '{{.SpecRoot}}/logrotate/traefik-access'
-    dest: /etc/logrotate.d/traefik-access
+  - src: '{{.SpecRoot}}/logrotate/{{.Name}}'
+    dest: /etc/logrotate.d/{{.Name}}
+  - src: '{{.SpecRoot}}/logrotate/{{.Name}}-access'
+    dest: /etc/logrotate.d/{{.Name}}-access
   - src: "{{empty}}"
     dest: /var/log/{{.Name}}
   - src: "{{empty}}"
@@ -50,7 +50,7 @@ targets:
   # config generation scripts
   - src: '{{.SpecRoot}}/config/'
     dest: /usr/bin/
-  - src: '{{.SpecRoot}}/traefik-restart'
+  - src: '{{.SpecRoot}}/{{.Name}}-restart'
     dest: /etc/sudoers.d/
 
 scripts:
@@ -73,8 +73,8 @@ scripts:
     systemctl enable /etc/systemd/system/{{.Name}}.service 2>/dev/null
     systemctl start {{.Name}}.service
 
-    sudo -u {{.Name}} traefik-global --port=80 --grace-time-out=10
-    sudo -u {{.Name}} traefik-web --address=:8080
+    sudo -u {{.Name}} {{.Name}}-global --port=80 --grace-time-out=10
+    sudo -u {{.Name}} {{.Name}}-web --address=:8080
 
   after-upgrade: |
     chown -R {{.Name}}:{{.Name}} /var/log/{{.Name}}


### PR DESCRIPTION
 * a lot of `{{.Name}}`s were templated in, so I went ahead and made it consistent
 * updated the URL to the new GH repo. 

tested and working with mantl on AWS