### PR TITLE
TRAEFIK FIX Remove extra Restart directive

### DIFF
--- a/packages/traefik/traefik.service
+++ b/packages/traefik/traefik.service
@@ -17,4 +17,3 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
-Restart=on-failure


### PR DESCRIPTION
The systemd unit file for traefik had an extra Restart directive in the
Install section. I've removed it