### PR TITLE
Modify docker run for centos, add obsolete warning after-install

### DIFF
--- a/mantl-cadvisor/mantl-cadvisor/mantl-cadvisor.service
+++ b/mantl-cadvisor/mantl-cadvisor/mantl-cadvisor.service
@@ -14,10 +14,12 @@ EnvironmentFile=/etc/sysconfig/mantl-cadvisor
 
 ExecStart=/bin/docker run \
   --net=host \
+  --privileged=true \
   --volume=/:/rootfs:ro \
   --volume=/var/run:/var/run:rw \
   --volume=/sys:/sys:ro \
   --volume=/var/lib/docker/:/var/lib/docker:ro \
+  --volume=cgroup:/cgroup:ro \
   --name=mantl-cadvisor \
   ${CADVISOR_IMAGE}:${CADVISOR_IMAGE_VERSION} \
   -housekeeping_interval=${HOUSEKEEPING_INTERVAL} -storage_driver_kafka_broker_list=${KAFKA_BROKER_LIST} -storage_driver_kafka_topic=${KAFKA_TOPIC} -storage_driver=kafka -port=${MANTL_CADVISOR_PORT} ${CADVISOR_OPTS}

--- a/mantl-cadvisor/mantl-cadvisor/mantl-cadvisor.sysconfig
+++ b/mantl-cadvisor/mantl-cadvisor/mantl-cadvisor.sysconfig
@@ -1,5 +1,5 @@
 CADVISOR_IMAGE=shippedrepos-docker-mantl-enterprise.bintray.io/mantl-cadvisor
-CADVISOR_IMAGE_VERSION=0.23.1.5
+CADVISOR_IMAGE_VERSION=0.23.1.7
 HOUSEKEEPING_INTERVAL=30s
 KAFKA_BROKER_LIST=localhost:9092
 KAFKA_TOPIC=metrics

--- a/mantl-cadvisor/mantl-cadvisor/spec.yml
+++ b/mantl-cadvisor/mantl-cadvisor/spec.yml
@@ -1,7 +1,7 @@
 name: mantl-cadvisor
 version: 0.23.1
 license: APL 2.0
-iteration: 7
+iteration: 8
 vendor: Google
 url: https://github.com/google/cadvisor
 architecture: x86_64
@@ -17,10 +17,11 @@ targets:
     config: true
 
 scripts:
-  after-upgrade:
+  after-upgrade: |
     systemctl daemon-reload
     systemctl restart mantl-cadvisor.service
   after-install: |
+    echo "WARNING: Obsolete package - final version."
     systemctl daemon-reload
     systemctl enable mantl-cadvisor.service 2>/dev/null
     systemctl start mantl-cadvisor.service


### PR DESCRIPTION
Modify cadvisor docker run command for centos.
Add obsolete warning for final package version.
Update cadvisor image to latest version 0.23.1.7.